### PR TITLE
Headless gui tests

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -27,9 +27,11 @@ jobs:
         conda install pip
         pip install -e .
     - name: Install test dependencies
+    # sudo apt-get install xvfb x11-utils gnumeric required for gui tests running in headless mode
       run: |
         conda install pip
         pip install -r dev-requirements.txt
+        sudo apt-get install xvfb x11-utils gnumeric
     - name: Test with pytest
       working-directory: tests
       run: |

--- a/desktop_shop/gui/init.py
+++ b/desktop_shop/gui/init.py
@@ -13,10 +13,18 @@ from desktop_shop.gui.components import Builder, Component, EntryFactory, Factor
 from desktop_shop.gui.views import views
 
 
+def _set_transparent_colour():
+    # this apparently fails on linux for no particular reason
+    try:
+        gui.root.wm_attributes("-transparentcolor", "purple")
+    except tk.TclError:
+        pass
+
+
 def init_root():
     """Initialises and configures tk root"""
     gui.root.title("OfflineShop")
-    gui.root.wm_attributes("-transparentcolor", "purple")
+    _set_transparent_colour()
     gui.root.config(bg=config.BG)
     for _ in range(21):
         gui.root.add_row(30)

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -6,6 +6,7 @@ tox
 # Testing.
 pytest
 pytest-cov
+pyvirtualdisplay
 
 # Type checking.
 mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,10 +22,17 @@ click==8.0.4
     # via
     #   black
     #   mkdocs
+colorama==0.4.6
+    # via
+    #   click
+    #   pytest
+    #   tox
 coverage[toml]==6.3.2
     # via pytest-cov
 distlib==0.3.4
     # via virtualenv
+exceptiongroup==1.1.0
+    # via pytest
 filelock==3.6.0
     # via
     #   tox
@@ -50,7 +57,9 @@ griffe==0.12.6
 idna==3.3
     # via requests
 importlib-metadata==4.11.1
-    # via mkdocs
+    # via
+    #   markdown
+    #   mkdocs
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
@@ -97,12 +106,12 @@ mkdocs-literate-nav==0.5.0
 mkdocs-material==8.2.7
     # via -r dev-requirements.in
 mkdocs-material-extensions==1.0.3
-    # via mkdocs-material
-mkdocstrings[python]==0.19.0
     # via
     #   -r dev-requirements.in
     #   mkdocstrings-python
 mkdocstrings-python==0.6.3
+    # via mkdocs-material
+mkdocstrings[python]==0.19.0
     # via mkdocstrings
 mypy==0.982
     # via -r dev-requirements.in
@@ -149,6 +158,8 @@ pytest-cov==4.0.0
     # via -r dev-requirements.in
 python-dateutil==2.8.2
     # via ghp-import
+pyvirtualdisplay==3.0
+    # via -r dev-requirements.in
 pyyaml==6.0
     # via
     #   mkdocs
@@ -167,11 +178,18 @@ six==1.16.0
 soupsieve==2.3.1
     # via beautifulsoup4
 tomli==2.0.1
-    # via coverage
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
+    #   tox
 tox==3.27.1
     # via -r dev-requirements.in
 typing-extensions==4.1.1
-    # via mypy
+    # via
+    #   black
+    #   mypy
 urllib3==1.26.8
     # via requests
 virtualenv==20.13.1

--- a/tests/unit/gui/callbacks_test.py
+++ b/tests/unit/gui/callbacks_test.py
@@ -36,6 +36,7 @@ ITERATIONS = 1
 def teardown():
     if display is not None:
         display.stop()
+        os.environ.pop("DISPLAY")
 
 
 def init_gui(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/gui/callbacks_test.py
+++ b/tests/unit/gui/callbacks_test.py
@@ -39,9 +39,6 @@ def teardown():
 
 
 def init_gui(monkeypatch: pytest.MonkeyPatch):
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-        pytest.skip("Tkinter cannot be initialised on headless server")
-
     generate_data.generate(
         TEST_DB,
         hash_iterations=ITERATIONS,

--- a/tests/unit/gui/callbacks_test.py
+++ b/tests/unit/gui/callbacks_test.py
@@ -13,6 +13,15 @@ import sys
 import sqlite3
 import pytest
 
+# fix for headless machines
+display = None  # pylint: disable=invalid-name
+if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+    from pyvirtualdisplay import Display
+
+    display = Display(visible=False, size=(100, 60))
+    display.start()
+
+# pylint: disable=wrong-import-position
 from desktop_shop.gui import callbacks, init
 from desktop_shop import gui
 from desktop_shop.user import UserSignUpData
@@ -22,17 +31,6 @@ TEST_DB = "file:cachedb?mode=memory&cache=shared"
 PASSWORD = "password123"
 EMAIL = "a@b.c"
 ITERATIONS = 1
-display = None  # pylint: disable=invalid-name
-
-
-def setup():
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-        # fix for headless machines
-        from pyvirtualdisplay import Display  # pylint: disable=import-outside-toplevel
-
-        global display  # pylint: disable=global-statement
-        display = Display(visible=False, size=(100, 60))
-        display.start()
 
 
 def teardown():

--- a/tests/unit/gui/callbacks_test.py
+++ b/tests/unit/gui/callbacks_test.py
@@ -36,7 +36,6 @@ ITERATIONS = 1
 def teardown():
     if display is not None:
         display.stop()
-        os.environ.pop("DISPLAY")
 
 
 def init_gui(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/gui/init_test.py
+++ b/tests/unit/gui/init_test.py
@@ -1,26 +1,34 @@
 # -*- coding: utf-8 -*-
 """Smoke tests for gui init function"""
+
+# pylint: disable=missing-function-docstring, missing-class-docstring
+
 from collections import namedtuple
 import os
 import sys
 
-import pytest
+# fix for headless machines
+display = None  # pylint: disable=invalid-name
+if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+    from pyvirtualdisplay import Display
 
+    display = Display(visible=False, size=(100, 60))
+    display.start()
+
+# pylint: disable=wrong-import-position
 from desktop_shop import database, server
+from desktop_shop import gui
+from desktop_shop.gui import init
 
 Product = namedtuple("Product", ["id", "name", "price"])
 
 
+def teardown():
+    if display is not None:
+        display.stop()
+
+
 def test_gui_init(monkeypatch):
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:  # FIXME
-        pytest.skip("Tkinter cannot be initialised on headless server")
-
-    from desktop_shop import gui
-    from desktop_shop.gui import init
-    from desktop_shop.gui.views import views
-
-    Product = namedtuple("Product", ["id", "name", "price"])
-
     def fake_products_query(*_, **__):
         return [
             Product(0, "a", 1000),
@@ -35,11 +43,6 @@ def test_gui_init(monkeypatch):
 
 
 def test_checkout_view():
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:  # FIXME
-        pytest.skip("Tkinter cannot be initialised on headless server")
-
-    from desktop_shop import gui
-
     class MonkeyPatch:
         def __enter__(self):
             self.func = server.query_product_data_from_product_table_by_product_ids

--- a/tests/unit/gui/init_test.py
+++ b/tests/unit/gui/init_test.py
@@ -7,6 +7,8 @@ from collections import namedtuple
 import os
 import sys
 
+from desktop_shop.gui.views import checkout
+
 # fix for headless machines
 display = None  # pylint: disable=invalid-name
 if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
@@ -53,9 +55,10 @@ def test_checkout_view():
         def __exit__(self, *_):
             server.query_product_data_from_product_table_by_product_ids = self.func
 
+    checkout_view = checkout.View.create(gui.root, init.init_builder())
     with MonkeyPatch():
         gui.app.data["cart"] = ["0"]
-        gui.app["checkout"].init_checkout()
+        checkout_view.init_checkout()
 
         # call again to cover code for the case of an already-built checkout View
-        gui.app["checkout"].init_checkout()
+        checkout_view.init_checkout()

--- a/tests/unit/gui/init_test.py
+++ b/tests/unit/gui/init_test.py
@@ -12,12 +12,12 @@ import pytest
 from desktop_shop.gui.views import checkout
 
 # fix for headless machines
-# display = None  # pylint: disable=invalid-name
-# if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-#     from pyvirtualdisplay import Display
+display = None  # pylint: disable=invalid-name
+if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+    from pyvirtualdisplay import Display
 
-#     display = Display(visible=False, size=(100, 60))
-#     display.start()
+    display = Display(visible=False, size=(100, 60))
+    display.start()
 
 # pylint: disable=wrong-import-position
 from desktop_shop import database, server
@@ -27,15 +27,12 @@ from desktop_shop.gui import init
 Product = namedtuple("Product", ["id", "name", "price"])
 
 
-# def teardown():
-#     if display is not None:
-#         display.stop()
+def teardown():
+    if display is not None:
+        display.stop()
 
 
 def test_gui_init(monkeypatch):
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-        pytest.skip()
-
     def fake_products_query(*_, **__):
         return [
             Product(0, "a", 1000),
@@ -50,9 +47,6 @@ def test_gui_init(monkeypatch):
 
 
 def test_checkout_view():
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-        pytest.skip()
-
     class MonkeyPatch:
         def __enter__(self):
             self.func = server.query_product_data_from_product_table_by_product_ids

--- a/tests/unit/gui/init_test.py
+++ b/tests/unit/gui/init_test.py
@@ -7,15 +7,17 @@ from collections import namedtuple
 import os
 import sys
 
+import pytest
+
 from desktop_shop.gui.views import checkout
 
 # fix for headless machines
-display = None  # pylint: disable=invalid-name
-if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-    from pyvirtualdisplay import Display
+# display = None  # pylint: disable=invalid-name
+# if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+#     from pyvirtualdisplay import Display
 
-    display = Display(visible=False, size=(100, 60))
-    display.start()
+#     display = Display(visible=False, size=(100, 60))
+#     display.start()
 
 # pylint: disable=wrong-import-position
 from desktop_shop import database, server
@@ -25,12 +27,15 @@ from desktop_shop.gui import init
 Product = namedtuple("Product", ["id", "name", "price"])
 
 
-def teardown():
-    if display is not None:
-        display.stop()
+# def teardown():
+#     if display is not None:
+#         display.stop()
 
 
 def test_gui_init(monkeypatch):
+    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+        pytest.skip()
+
     def fake_products_query(*_, **__):
         return [
             Product(0, "a", 1000),
@@ -45,6 +50,9 @@ def test_gui_init(monkeypatch):
 
 
 def test_checkout_view():
+    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+        pytest.skip()
+
     class MonkeyPatch:
         def __enter__(self):
             self.func = server.query_product_data_from_product_table_by_product_ids

--- a/tests/unit/gui/init_test.py
+++ b/tests/unit/gui/init_test.py
@@ -11,13 +11,6 @@ import pytest
 
 from desktop_shop.gui.views import checkout
 
-# fix for headless machines
-display = None  # pylint: disable=invalid-name
-if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
-    from pyvirtualdisplay import Display
-
-    display = Display(visible=False, size=(100, 60))
-    display.start()
 
 # pylint: disable=wrong-import-position
 from desktop_shop import database, server
@@ -27,12 +20,10 @@ from desktop_shop.gui import init
 Product = namedtuple("Product", ["id", "name", "price"])
 
 
-def teardown():
-    if display is not None:
-        display.stop()
-
-
 def test_gui_init(monkeypatch):
+    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+        pytest.skip()
+
     def fake_products_query(*_, **__):
         return [
             Product(0, "a", 1000),
@@ -47,6 +38,9 @@ def test_gui_init(monkeypatch):
 
 
 def test_checkout_view():
+    if sys.platform.startswith("linux") and os.environ.get("DISPLAY") is None:
+        pytest.skip()
+
     class MonkeyPatch:
         def __enter__(self):
             self.func = server.query_product_data_from_product_table_by_product_ids


### PR DESCRIPTION
Fix gui unit tests for Github Actions headless linux server. Tkinter requires a display to be initialised, so using a pyvirtualdisplay to fake having a display and allowing tests to run.