### PR TITLE
Fix database package

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -23,6 +23,7 @@ jobs:
     # sudo apt-get install xvfb x11-utils gnumeric required for gui tests running in headless mode
       run: |
         pip install -r dev-requirements.txt
+        sudo apt-get update
         sudo apt-get install xvfb x11-utils gnumeric
     - name: Test with pytest
       working-directory: tests


### PR DESCRIPTION
This fixes the `desktop_shop.database` package not being correctly installed with pip, resulting in failing lib builds if installing with pip using the latest pypi package version.